### PR TITLE
Encoded auth credentials

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ module.exports = function resolver(bower) {
      */
     _buildAuth: function() {
 			if (bower.config.nexus && bower.config.nexus.auth) {
-				return new Buffer(bower.config.nexus.auth, 'base64').toString(); //.toString("ascii");
+				return new Buffer(bower.config.nexus.auth, 'base64').toString();
 			}
       if (bower.config.nexus && bower.config.nexus.username && bower.config.nexus.password) {
         return bower.config.nexus.username + ':' + bower.config.nexus.password;

--- a/src/index.js
+++ b/src/index.js
@@ -123,6 +123,9 @@ module.exports = function resolver(bower) {
      * @private
      */
     _buildAuth: function() {
+			if (bower.config.nexus && bower.config.nexus.auth) {
+				return new Buffer(bower.config.nexus.auth, 'base64').toString(); //.toString("ascii");
+			}
       if (bower.config.nexus && bower.config.nexus.username && bower.config.nexus.password) {
         return bower.config.nexus.username + ':' + bower.config.nexus.password;
       }

--- a/test/resolver-test.js
+++ b/test/resolver-test.js
@@ -249,6 +249,25 @@ describe('bower-nexus3-resolver', function() {
         repositoryName: 'reponame',
         packageName: 'packagename'
       });
+	    it('should build a url with base64 encoded auth information for nexus', function() {
+	      var resolver = resolverFactory({
+	        config: {
+	          nexus: {
+	            auth: 'dXNlcjpwYXNz'
+	          }
+	        }
+	      });
+	      var actual = resolver._buildNexusVersionsEndpoint({
+	        protocol: 'http:',
+	        hostname: 'hostname',
+	        port: '8080',
+	        path: '/repository',
+	        repositoryName: 'reponame',
+	        packageName: 'packagename'
+	      });
+	      var expected = 'http://user:pass@hostname:8080/repository/reponame/packagename/versions.json';
+	      assert.deepEqual(actual, expected);
+	    });
       var expected = 'http://user:pass@hostname:8080/repository/reponame/packagename/versions.json';
       assert.deepEqual(actual, expected);
     });
@@ -258,6 +277,25 @@ describe('bower-nexus3-resolver', function() {
           nexus: {
             username: 'user',
             password: 'pass'
+          }
+        }
+      });
+      var actual = resolver._buildNexusVersionsEndpoint({
+        protocol: 'http:',
+        hostname: 'hostname',
+        port: '8080',
+        path: '/context/path/repository',
+        repositoryName: 'reponame',
+        packageName: 'packagename'
+      });
+      var expected = 'http://user:pass@hostname:8080/context/path/repository/reponame/packagename/versions.json';
+      assert.deepEqual(actual, expected);
+    });
+    it('should build a url with context path with base64 encoded auth information for nexus', function() {
+      var resolver = resolverFactory({
+        config: {
+          nexus: {
+            auth: 'dXNlcjpwYXNz'
           }
         }
       });
@@ -343,6 +381,25 @@ describe('bower-nexus3-resolver', function() {
       var expected = 'http://user:pass@hostname:8080/repository/reponame/packagename/1.2.3/package.tar.gz';
       assert.deepEqual(actual, expected);
     });
+    it('should build a url with base64 encoded auth information in Nexus', function() {
+      var resolver = resolverFactory({
+        config: {
+          nexus: {
+            auth: 'dXNlcjpwYXNz'
+          }
+        }
+      });
+      var actual = resolver._buildNexusArchiveEndpoint({
+        protocol: 'http:',
+        hostname: 'hostname',
+        port: '8080',
+        path: '/repository',
+        repositoryName: 'reponame',
+        packageName: 'packagename'
+      }, '1.2.3');
+      var expected = 'http://user:pass@hostname:8080/repository/reponame/packagename/1.2.3/package.tar.gz';
+      assert.deepEqual(actual, expected);
+    });
     it('should build a url with context path with auth information in Nexus', function() {
       var resolver = resolverFactory({
         config: {
@@ -379,6 +436,18 @@ describe('bower-nexus3-resolver', function() {
       var expected = 'user:pass';
       assert.deepEqual(actual, expected);
     });
+		it('should build an auth string when base64 encoded credentials are present', function() {
+			var resolver = resolverFactory({
+				config: {
+					nexus: {
+						auth: 'dXNlcjpwYXNz'
+					}
+				}
+			});
+			var actual = resolver._buildAuth();
+			var expected = 'user:pass';
+			assert.deepEqual(actual, expected);
+		});
     it('should not build an auth string when both username and password are absent', function() {
       var actual = resolver._buildAuth();
       var expected = null;

--- a/test/resolver-test.js
+++ b/test/resolver-test.js
@@ -249,25 +249,25 @@ describe('bower-nexus3-resolver', function() {
         repositoryName: 'reponame',
         packageName: 'packagename'
       });
-	    it('should build a url with base64 encoded auth information for nexus', function() {
-	      var resolver = resolverFactory({
-	        config: {
-	          nexus: {
-	            auth: 'dXNlcjpwYXNz'
-	          }
-	        }
-	      });
-	      var actual = resolver._buildNexusVersionsEndpoint({
-	        protocol: 'http:',
-	        hostname: 'hostname',
-	        port: '8080',
-	        path: '/repository',
-	        repositoryName: 'reponame',
-	        packageName: 'packagename'
-	      });
-	      var expected = 'http://user:pass@hostname:8080/repository/reponame/packagename/versions.json';
-	      assert.deepEqual(actual, expected);
-	    });
+      var expected = 'http://user:pass@hostname:8080/repository/reponame/packagename/versions.json';
+      assert.deepEqual(actual, expected);
+    });
+    it('should build a url with base64 encoded auth information for nexus', function() {
+      var resolver = resolverFactory({
+        config: {
+          nexus: {
+            auth: 'dXNlcjpwYXNz'
+          }
+        }
+      });
+      var actual = resolver._buildNexusVersionsEndpoint({
+        protocol: 'http:',
+        hostname: 'hostname',
+        port: '8080',
+        path: '/repository',
+        repositoryName: 'reponame',
+        packageName: 'packagename'
+      });
       var expected = 'http://user:pass@hostname:8080/repository/reponame/packagename/versions.json';
       assert.deepEqual(actual, expected);
     });


### PR DESCRIPTION
For enterprise users it is not an option to have clear text credentials in the configuration files. At a minimum they must be encoded. With the attached changes its possible to base64 encode the user credentials and include them in the .bowerrc file. For example:

To encode credentials you could run
````
echo -n "user:pass" | openssl base64
dXNlcjpwYXNz
````
The following configuration would be necessary to use the encoded credentials:
````
cat .bowerrc
{
  nexus: {
    auth: 'dXNlcjpwYXNz'
  }
}
````