### PR TITLE
fix. Unnecessary setting of proxy option of request's config.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -272,7 +272,6 @@ module.exports = function resolver(bower) {
       return {
         url: url,
         encoding: encoding,
-        proxy: url.indexOf('https://') < 0 ? bower.config.httpsProxy : bower.config.proxy,
         strictSSL: bower.config.strictSsl,
         ca: bower.config.ca ? bower.config.ca.default : null,
         timeout: bower.config.timeout


### PR DESCRIPTION
The request module uses the values of environment variables and the config's bower overwrites the process environment variables with config values. When proxy option is setted in request module, the no_proxy values are avoided.