### PR TITLE
Fix for tar.extract new method option

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "tmp": "~0.0.33"
   },
   "devDependencies": {
-    "mocha": "~6.0.2",
+    "mocha": "^6.1.3",
     "mocha-junit-reporter": "~1.18.0",
     "nock": "~10.0.6",
     "sinon": "~7.2.7"

--- a/src/index.js
+++ b/src/index.js
@@ -252,7 +252,7 @@ module.exports = function resolver(bower) {
           reject(err);
         });
 
-        var tarStream = tar.extract({path: tempDir.name});
+        var tarStream = tar.extract({cwd: tempDir.name});
         tarStream.on('error', function(err) {
           reject(err);
         });


### PR DESCRIPTION
After https://github.com/sonatype/bower-nexus3-resolver/commit/e71c22d4d7a632e5906898e52dd44d08856b50da upgrade of tar from 2.2.1 to 4.4.8 the resolver is still completely broken if you use tar dependencies.

The options of tar had changed from 
> path: '/path/to/extract/tar/into',

to

> cwd: Extract files relative to the specified directory. Defaults to process.cwd(). If provided, this must exist and must be a directory. [Alias: C]

Wasn't able to adjust the fetch test case. Maybe someone else can do.

Please consider 1.0.3 and 1.0.4 as not working.

Would be nice if you can release this PR as 1.0.5 soon.

This fixes #27 